### PR TITLE
Pass through kwargs to callback function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,3 +4,4 @@ v0.1.2, 2017-08-01 -- Change minimum Django to 1.3 (to match django yaml redirec
 v0.2.0, 2017-08-01 -- Rename kew function to "create_views_from_file"
 v0.2.1, 2017-08-01 -- Fix dependencies in setup.py
 v0.2.2, 2017-08-01 -- Make created views more resilient to erroneous options
+v0.2.2, 2017-11-22 -- Pass through kwargs to the callback function

--- a/canonicalwebteam/views_from_yaml/__init__.py
+++ b/canonicalwebteam/views_from_yaml/__init__.py
@@ -10,7 +10,7 @@ def _create_view(url_settings, view_callback):
     """
 
     def url_view(request, *args, **kwargs):
-        return view_callback(request, url_settings)
+        return view_callback(request, url_settings, *args, **kwargs)
 
     return url_view
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='canonicalwebteam.views-from-yaml',
-    version='0.2.2',
+    version='0.2.3',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/canonical-webteam/views-from-yaml',


### PR DESCRIPTION
This is needed so that arguments on the URL are passed through. E.g. for redirects.